### PR TITLE
Catch err

### DIFF
--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -42,6 +42,7 @@ module.exports = (app) => {
                     .then((newOrg) => {
                         // creates the new User after a new Org was created
                         signUser(newOrg, req.body, res).then(() => {
+                            // Updates the new Org to have the creating User as 'admin'
                             setTimeout(() => {
                                 db.User.findAll({
                                     where: {

--- a/routes/html-routes.js
+++ b/routes/html-routes.js
@@ -8,14 +8,14 @@ module.exports = (app) => {
         if (req.user) {
             res.redirect('/dashboard');
         }
-        res.render('index')
+        res.render('index');
     });
 
     app.get('/index', (req, res) => {
         if (req.user) {
             res.redirect('/dashboard');
         }
-        res.render('index')
+        res.render('index');
     });
 
     // Sign Up Route
@@ -23,12 +23,12 @@ module.exports = (app) => {
         if (req.user) {
             res.redirect('/dashboard');
         }
-        res.render("login")
+        res.render("login");
     });
 
-    app.get("/dashboard", isAuthenticated, function (req, res) {
-        console.log('//// HTML ROUTE ////')
-        console.log(req.user)
-        res.render("dash-home")
+    app.get("/dashboard", isAuthenticated, (req, res) => {
+        console.log('//// HTML ROUTE ////');
+        console.log(req.user);
+        res.render("dash-home");
     });
 }

--- a/routes/idea-api-routes.js
+++ b/routes/idea-api-routes.js
@@ -17,6 +17,12 @@ module.exports = (app) => {
   });
 
   app.post('/api/ideas/', (req, res) => {
-    db.Idea.create(req.body).then((dbIdea) => res.json(dbIdea));
+    db.Idea.create(req.body).then((dbIdea) => {
+      res.status(201).json(dbIdea);
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status(400).json(err);
+    });
   });
 };

--- a/routes/idea-api-routes.js
+++ b/routes/idea-api-routes.js
@@ -2,7 +2,8 @@ const db = require('../models');
 
 module.exports = (app) => {
   app.get('/api/ideas/', (req, res) => {
-    db.Idea.findAll().then((dbIdea) => {
+    db.Idea.findAll()
+    .then((dbIdea) => {
       if (dbIdea.length > 0) {
         res.status(200).json(dbIdea);
       }
@@ -17,7 +18,8 @@ module.exports = (app) => {
   });
 
   app.post('/api/ideas/', (req, res) => {
-    db.Idea.create(req.body).then((dbIdea) => {
+    db.Idea.create(req.body)
+    .then((dbIdea) => {
       res.status(201).json(dbIdea);
     })
     .catch((err) => {

--- a/routes/idea-api-routes.js
+++ b/routes/idea-api-routes.js
@@ -2,7 +2,18 @@ const db = require('../models');
 
 module.exports = (app) => {
   app.get('/api/ideas/', (req, res) => {
-    db.Idea.findAll().then((dbIdea) => res.json(dbIdea));
+    db.Idea.findAll().then((dbIdea) => {
+      if (dbIdea.length > 0) {
+        res.status(200).json(dbIdea);
+      }
+      else {
+        res.status(404).json(dbIdea);
+      }
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status(500).json(err);
+    });
   });
 
   app.post('/api/ideas/', (req, res) => {

--- a/routes/org-api-routes.js
+++ b/routes/org-api-routes.js
@@ -25,5 +25,4 @@ module.exports = (app) => {
       res.status(400).json(err);
     });
   });
-
 };

--- a/routes/org-api-routes.js
+++ b/routes/org-api-routes.js
@@ -2,7 +2,8 @@ const db = require('../models');
 
 module.exports = (app) => {
   app.get('/api/orgs/', (req, res) => {
-    db.Org.findAll().then((dbOrg) => {
+    db.Org.findAll()
+    .then((dbOrg) => {
       if (dbOrg.length > 0) {
         res.status(200).json(dbOrg);
       }
@@ -17,7 +18,8 @@ module.exports = (app) => {
   });
 
   app.post('/api/orgs/', (req, res) => {
-    db.Org.create(req.body).then((dbOrg) => {
+    db.Org.create(req.body)
+    .then((dbOrg) => {
       res.status(201).json(dbOrg);
     })
     .catch((err) => {

--- a/routes/poll-api-routes.js
+++ b/routes/poll-api-routes.js
@@ -2,7 +2,8 @@ const db = require('../models');
 
 module.exports = (app) => {
   app.get('/api/polls/', (req, res) => {
-    db.Poll.findAll().then((dbPoll) => {
+    db.Poll.findAll()
+    .then((dbPoll) => {
       if (dbPoll.length > 0) {
         res.status(200).json(dbPoll);
       } 
@@ -18,7 +19,8 @@ module.exports = (app) => {
   });
 
   app.post('/api/polls/', (req, res) => {
-    db.Poll.create(req.body).then((dbPoll) => {
+    db.Poll.create(req.body)
+    .then((dbPoll) => {
       res.status(201).json(dbPoll)
     })
     .catch((err) => {

--- a/routes/poll-api-routes.js
+++ b/routes/poll-api-routes.js
@@ -5,7 +5,8 @@ module.exports = (app) => {
     db.Poll.findAll().then((dbPoll) => {
       if (dbPoll.length > 0) {
         res.status(200).json(dbPoll);
-      } else {
+      } 
+      else {
         res.status(404).json(dbPoll);
       }
       
@@ -17,6 +18,12 @@ module.exports = (app) => {
   });
 
   app.post('/api/polls/', (req, res) => {
-    db.Poll.create(req.body).then((dbPoll) => res.json(dbPoll));
+    db.Poll.create(req.body).then((dbPoll) => {
+      res.status(201).json(dbPoll)
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status(400).json(err);
+    });
   });
 };

--- a/routes/poll-api-routes.js
+++ b/routes/poll-api-routes.js
@@ -2,7 +2,18 @@ const db = require('../models');
 
 module.exports = (app) => {
   app.get('/api/polls/', (req, res) => {
-    db.Poll.findAll().then((dbPoll) => res.json(dbPoll));
+    db.Poll.findAll().then((dbPoll) => {
+      if (dbPoll.length > 0) {
+        res.status(200).json(dbPoll);
+      } else {
+        res.status(404).json(dbPoll);
+      }
+      
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status(500).json(err);
+    });
   });
 
   app.post('/api/polls/', (req, res) => {

--- a/routes/user-api-routes.js
+++ b/routes/user-api-routes.js
@@ -15,9 +15,4 @@ module.exports = (app) => {
       res.status(500).json(err);
     });
   });
-
-  app.post('/api/users/', (req, res) => {
-    console.log(req.body);
-    db.User.create(req.body).then((dbUser) => res.json(dbUser));
-  });
 };

--- a/routes/user-api-routes.js
+++ b/routes/user-api-routes.js
@@ -2,7 +2,18 @@ const db = require('../models');
 
 module.exports = (app) => {
   app.get('/api/users/', (req, res) => {
-    db.User.findAll().then((dbUser) => res.json(dbUser));
+    db.User.findAll().then((dbUser) => {
+      if (dbUser.length > 0) {
+        res.status(200).json(dbUser);
+      }
+      else {
+        res.status(404).json(dbUser);
+      }
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status(500).json(err);
+    });
   });
 
   app.post('/api/users/', (req, res) => {

--- a/routes/user-api-routes.js
+++ b/routes/user-api-routes.js
@@ -2,7 +2,8 @@ const db = require('../models');
 
 module.exports = (app) => {
   app.get('/api/users/', (req, res) => {
-    db.User.findAll().then((dbUser) => {
+    db.User.findAll()
+    .then((dbUser) => {
       if (dbUser.length > 0) {
         res.status(200).json(dbUser);
       }


### PR DESCRIPTION
closes #62

Adds response codes and error handling to API routes to make it easier to debug in case we make bad requests or are not getting any data back from MySQL.

Removes ability to POST new users directly to /api/users/ as they would not use the sign up flow to generate secure passwords.